### PR TITLE
fix validate for assoc

### DIFF
--- a/web/models/post_praise.ex
+++ b/web/models/post_praise.ex
@@ -14,6 +14,7 @@ defmodule PhoenixChina.PostPraise do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:user_id, :post_id])
-    |> validate_required([:user_id, :post_id])
+    |> assoc_constraint(:user)
+    |> assoc_constraint(:post)
   end
 end


### PR DESCRIPTION
`validate_required` 只能验证字段不为空，`assoc_constraint` 可以保证外键的值在数据库中已经存在。